### PR TITLE
Render partial from component directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,15 +137,14 @@ a.button(href=@href)
 
 ### Component partials
 
-You can also choose to split your component into partials. In this case, use the `render_partial` helper to render a partial, stored inside the component directory. It's a simple shorthand of the default `render` helper from Rails. 
+You can also choose to split your component into partials. In this case, we can use the default `render` helper to render a partial, stored inside the component directory.
 
 ```slim
 / frontend/components/button/_button.html.slim
 
 = a.button(href=@href)
   = @text
-  / The line below is similar to: render("components/button/suffix", text: "external link") if external_link?
-  = render_partial("suffix", text: "external link") if external_link?
+  = render("suffix", text: "external link") if external_link?
 ```
 
 ```slim

--- a/lib/komponent/komponent_helper.rb
+++ b/lib/komponent/komponent_helper.rb
@@ -51,26 +51,26 @@ module KomponentHelper
   alias :c :component
 
   def render_partial(partial_name, locals = {}, &block)
-    benchmark("Rendered partial #{partial_name}") do
-      context = controller.view_context
-      view_paths = context.lookup_context.view_paths.dup
-      components_path = Rails.root.join "frontend/components"
+    warn "[DEPRECATION] `render_partial` is deprecated. Please use default `render` instead."
 
-      capture_block = proc { capture(&block) } if block
+    context = controller.view_context
+    view_paths = context.lookup_context.view_paths.dup
+    components_path = Rails.root.join "frontend/components"
 
-      current_dir = Pathname.new(@virtual_path).dirname
+    capture_block = proc { capture(&block) } if block
 
-      context.lookup_context.prefixes.prepend current_dir
-      context.lookup_context.view_paths.unshift components_path
+    current_dir = Pathname.new(@virtual_path).dirname
 
-      rendered_partial = capture do 
-        context.render partial_name, locals, &capture_block
-      end
+    context.lookup_context.prefixes.prepend current_dir
+    context.lookup_context.view_paths.unshift components_path
 
-      context.lookup_context.prefixes.delete current_dir
-      context.lookup_context.view_paths = view_paths
-
-      rendered_partial
+    rendered_partial = capture do 
+      context.render partial_name, locals, &capture_block
     end
+
+    context.lookup_context.prefixes.delete current_dir
+    context.lookup_context.view_paths = view_paths
+
+    rendered_partial
   end
 end

--- a/lib/komponent/komponent_helper.rb
+++ b/lib/komponent/komponent_helper.rb
@@ -10,6 +10,7 @@ module KomponentHelper
 
     component_module = "#{component_name}_component".camelize.constantize
     context = controller.view_context.dup
+    context.view_flow = view_flow
     context.class_eval { prepend component_module }
     capture_block = proc { capture(&block) } if block
 

--- a/lib/komponent/komponent_helper.rb
+++ b/lib/komponent/komponent_helper.rb
@@ -10,8 +10,15 @@ module KomponentHelper
 
     component_module = "#{component_name}_component".camelize.constantize
     context = controller.view_context.dup
+
     context.view_flow = view_flow
+
+    view_renderer = context.view_renderer = context.view_renderer.dup
+    lookup_context = view_renderer.lookup_context = view_renderer.lookup_context.dup
+    lookup_context.prefixes = ["components/#{component}"]
+
     context.class_eval { prepend component_module }
+
     capture_block = proc { capture(&block) } if block
 
     context.instance_eval do


### PR DESCRIPTION
Inspired by #20 and including #21 (to avoid merge conflict).

With this change a `render "partial"` will look for the partial in the component directory, and not anymore in `app/views/<controller name>`. It's still possible to render an explicit partial from `views` with for example `render "home/partial"`.