### PR TITLE
Fix rubocop namespaces

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,21 +52,15 @@ Naming/PredicateName:
 Naming/VariableName:
   Enabled: true
 
-Lint/BlockAlignment:
-  Enabled: true
-  EnforcedStyleAlignWith: start_of_block
-
-Lint/ConditionPosition:
-  Enabled: true
-
-Lint/DefEndAlignment:
-  Enabled: true
-
 Lint/DeprecatedClassMethods:
   Enabled: true
 
 Layout/AlignParameters:
   Enabled: true
+
+Layout/BlockAlignment:
+  Enabled: true
+  EnforcedStyleAlignWith: start_of_block
 
 Layout/BlockEndNewline:
   Enabled: true
@@ -75,6 +69,12 @@ Layout/CaseIndentation:
   Enabled: true
 
 Layout/ClosingParenthesisIndentation:
+  Enabled: true
+
+Layout/ConditionPosition:
+  Enabled: true
+
+Layout/DefEndAlignment:
   Enabled: true
 
 Layout/DotPosition:


### PR DESCRIPTION
```
.rubocop.yml: Lint/BlockAlignment has the wrong namespace - should be Layout
.rubocop.yml: Lint/ConditionPosition has the wrong namespace - should be Layout
.rubocop.yml: Lint/DefEndAlignment has the wrong namespace - should be Layout
```