### PR TITLE
Fix install generator without stimulus

### DIFF
--- a/lib/generators/komponent/install_generator.rb
+++ b/lib/generators/komponent/install_generator.rb
@@ -38,8 +38,9 @@ module Komponent
 
       def create_stimulus_file
         return if File.exist?(stimulus_application_path)
+        return unless stimulus?
 
-        create_file(stimulus_application_path, stimulus? ? stimulus_application_template : "")
+        create_file(stimulus_application_path, stimulus_application_template)
       end
 
       def append_to_application_configuration


### PR DESCRIPTION
Currently the `stimulus_application.js` file is always created (but it is empty when the `--stimulus` option is not passed).

We should actually create the file only if the `--stimulus` option is passed.