### PR TITLE
Use component_name instead of module_name in templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Upcoming release
 
+**Enhancements:**
+
+- Component generator: use `component_name` instead of `module_name` in templates,
+  so when we create a `button` component, by default it contains `button` instead
+  of `button_component`
+
 ## v2.1.0 (2018-05-31)
 
 **Enhancements:**

--- a/lib/generators/component/templates/view.html.erb.erb
+++ b/lib/generators/component/templates/view.html.erb.erb
@@ -2,6 +2,6 @@
   <%- if locale? -%>
   <%%= t ".component_name" %>
   <%- else -%>
-  <%= module_name.underscore %>
+  <%= component_name.underscore %>
   <%- end -%>
 </div>

--- a/lib/generators/component/templates/view.html.haml.erb
+++ b/lib/generators/component/templates/view.html.haml.erb
@@ -2,5 +2,5 @@
   <%- if locale? -%>
   = t ".component_name"
   <%- else -%>
-  <%= module_name.underscore %>
+  <%= component_name.underscore %>
   <%- end -%>

--- a/lib/generators/component/templates/view.html.slim.erb
+++ b/lib/generators/component/templates/view.html.slim.erb
@@ -2,5 +2,5 @@
   <%- if locale? -%>
   = t ".component_name"
   <%- else -%>
-  | <%= module_name.underscore %>
+  | <%= component_name.underscore %>
   <%- end -%>


### PR DESCRIPTION
So when we create a `button` component, by default it contains `button` instead of `button_component` (makes more sense imho)