### PR TITLE
Cleanup i18n dynamic path for locale file paths

### DIFF
--- a/features/install_generator.feature
+++ b/features/install_generator.feature
@@ -5,7 +5,7 @@ Feature: Install generator
     When I run `rails generate komponent:install`
     And the file named "config/application.rb" should contain:
     """
-    config.i18n.load_path += Dir[config.root.join('frontend/components/**/*.yml')]
+    config.i18n.load_path += Dir[config.root.join('frontend/components/**/*.*.yml')]
     """
     And the file named "config/application.rb" should contain:
     """

--- a/fixtures/my_app/config/application.rb
+++ b/fixtures/my_app/config/application.rb
@@ -12,6 +12,6 @@ Bundler.require(*Rails.groups)
 
 module MyApp
   class Application < Rails::Application
-    config.i18n.load_path += Dir[config.root.join('frontend/components/**/*.yml')]
+    config.i18n.load_path += Dir[config.root.join('frontend/components/**/*.*.yml')]
   end
 end

--- a/lib/generators/komponent/install_generator.rb
+++ b/lib/generators/komponent/install_generator.rb
@@ -45,7 +45,7 @@ module Komponent
 
       def append_to_application_configuration
         application "config.autoload_paths << config.root.join('#{relative_path_from_rails}/components')"
-        application "config.i18n.load_path += Dir[config.root.join('#{relative_path_from_rails}/components/**/*.yml')]"
+        application "config.i18n.load_path += Dir[config.root.join('#{relative_path_from_rails}/components/**/*.*.yml')]"
       end
 
       def append_to_application_pack


### PR DESCRIPTION
Use a more precise path fot i18n load_path to avoid loading other yaml
file on components.

On a project I created an `image` component to easily generate an html `picture` tag. And so I also create a `formats.yml` to store my images formats I want to use.
And so with the current path used for `i18n.load_path`, my `formats.yml` file is loaded with locale files.

I do this update on my app and it seems good enough.