### PR TITLE
Makes component_name variable accessible for example generator

### DIFF
--- a/lib/generators/component/templates/examples.html.erb.erb
+++ b/lib/generators/component/templates/examples.html.erb.erb
@@ -1,3 +1,3 @@
 <h1 class="komponent-title"><%%= @component.title %></h1>
 
-<%%= cdoc "<%= component_name %>" %>
+<%%= cdoc "<%= @component_name %>" %>

--- a/lib/generators/component/templates/examples.html.haml.erb
+++ b/lib/generators/component/templates/examples.html.haml.erb
@@ -1,3 +1,3 @@
 %h1.komponent-title= @component.title
 
-= cdoc "<%= component_name %>"
+= cdoc "<%= @component_name %>"

--- a/lib/generators/component/templates/examples.html.slim.erb
+++ b/lib/generators/component/templates/examples.html.slim.erb
@@ -1,3 +1,3 @@
 h1.komponent-title= @component.title
 
-= cdoc "<%= component_name %>"
+= cdoc "<%= @component_name %>"

--- a/lib/generators/komponent/examples_generator.rb
+++ b/lib/generators/komponent/examples_generator.rb
@@ -31,6 +31,7 @@ module Komponent
       private
 
       def create_examples_view_file(component_name)
+        @component_name = component_name
         template "examples.html.#{template_engine}.erb", component_path(component_name) + "_examples.html.#{template_engine}"
       end
     end


### PR DESCRIPTION
Closes #158 

Not sure if this is the right approach or if we can simply use `@component.id` for the call.

Let me know if this is okay.