### PR TITLE
Allow injecting a custom renderer class

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,9 +55,6 @@ Naming/PredicateName:
 Naming/VariableName:
   Enabled: true
 
-Layout/AlignParameters:
-  Enabled: true
-
 Layout/BlockAlignment:
   Enabled: true
   EnforcedStyleAlignWith: start_of_block
@@ -87,6 +84,9 @@ Layout/EmptyLines:
   Enabled: true
 
 Layout/EmptyLinesAroundAccessModifier:
+  Enabled: true
+
+Layout/ParameterAlignment:
   Enabled: true
 
 Layout/SpaceAroundBlockParameters:

--- a/lib/komponent/komponent_helper.rb
+++ b/lib/komponent/komponent_helper.rb
@@ -5,7 +5,8 @@ require 'komponent/component'
 module KomponentHelper
   def component(component_name, locals = {}, options = {}, &block)
     captured_block = proc { |args| capture(args, &block) } if block_given?
-    Komponent::ComponentRenderer.new(
+    renderer_klass = options.delete(:renderer) || Komponent::ComponentRenderer
+    renderer_klass.new(
       controller,
       view_flow || (view && view.view_flow),
     ).render(

--- a/test/komponent/komponent_helper_test.rb
+++ b/test/komponent/komponent_helper_test.rb
@@ -9,6 +9,18 @@ class KomponentHelperTest < ActionView::TestCase
     end
   end
 
+  def test_inject_custom_renderer
+    custom_renderer_klass = Class.new(Komponent::ComponentRenderer) do
+      def render(*args)
+        'custom_render_method'
+      end
+    end
+
+    assert_equal \
+      'custom_render_method',
+      component('world', {}, renderer: custom_renderer_klass)
+  end
+
   def test_helper_renders_namespaced_component
     assert_equal \
       %(<div class="namespaced-button">namespaced_button_component</div>),


### PR DESCRIPTION
This PR does not really alter the behaviour of the gem, but it allows easier implementation for custom behaviour.

- The `component` helper optionally accepts a custom renderer class
- The `ComponentRenderer` itself has been refactored a bit to allow customization of property assignment

Use case:
We'd like to use `komponent` in a setup where we need to customize the property assignment to enable localization (including inline editing).
The changes in this PR would implement an interface for customization only - without binding to a special kind of customization.

Note: The `.rubocop.yml` change is due to a warning by rubocop itself